### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Run Prettier code style checks
         run: npx prettier -c .
       - name: Upload to Codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
Reverts nasa-gcn/architect-plugin-tracing#9. See https://github.com/codecov/codecov-action/issues/1293.