### PR TITLE
Fix TypeScript file extension warning

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'path'
-import { exists } from './paths'
+import { exists } from './paths.js'
 
 export const deploy = {
   async start({


### PR DESCRIPTION
Fix the following warning from TypeScript: `Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './paths.js'?`